### PR TITLE
Update build, deployment configurations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ title: Fathom
 description: Fathom Analytics provides very simple website stats without tracking or storing personal data.
 author: esune
 resourceType: Components
-personas: 
+personas:
   - Developer
   - Product Owner
   - Designer
@@ -12,59 +12,67 @@ labels:
   - analytics
   - web
 ---
+
 # Fathom
 
-Fathom Analytics provides very simple website stats without tracking or storing personal data.  If you require more comprehensive analytics, a Google Analytics alternative, where data ownership and privacy compliance are still a concern check out [Matomo Openshift](https://github.com/BCDevOps/matomo-openshift).
+Fathom Analytics provides very simple website stats without tracking or storing personal data. If you require more comprehensive analytics, a Google Analytics alternative, where data ownership and privacy compliance are still a concern check out [Matomo Openshift](https://github.com/BCDevOps/matomo-openshift).
 
 [fathom-openshift](https://github.com/BCDevOps/fathom-openshift) is a set of OpenShift configurations to set up an instance of the Fathom web analytics server. See: [Fathom](usefathom.com)
 
 ## Architecture
+
 The service is composed by the following components:
-- *fathom*: the main analytics service.
-- *fathom-db*: a [postgresql](https://www.postgresql.org) instance that will be used to store the analytics data.
-- *fathom-proxy*: the [nginx](https://www.nginx.com) service used as reverse-proxy
+
+- _fathom_: the main analytics service.
+- _fathom-db_: a [postgresql](https://www.postgresql.org) instance that will be used to store the analytics data.
+- _fathom-proxy_: the [nginx](https://www.nginx.com) service used as reverse-proxy
 
 ## Deployment / Configuration
-The templates provided in the `openshift` folder include everything that is necessary to create the required builds and deployments.  
 
-To run Fathom on openshift you **MUST** install [openshift-developer-tools](https://github.com/BCDevOps/openshift-developer-tools) and have them available on your path  
+The templates provided in the `openshift` folder include everything that is necessary to create the required builds and deployments.
 
-By default, Fathom uses the artifactory docker registry. If you are going to keep the default settings artifactory **MUST** be enabled in your OCP cluster, otherwise you will have to tweak the param file to specify your docker registry.  
+To run Fathom on openshift you **MUST** install [openshift-developer-tools](https://github.com/BCDevOps/openshift-developer-tools) and have them available on your path
 
+By default, Fathom uses the Artifactory docker registry. If you are going to keep the default settings, Artifactory **MUST** be enabled in your OCP cluster, otherwise you will have to tweak the param file to specify your docker registry.
 
 ##### Running with Artifactory/docker.io:
-There should already be a "artifacts-default-\*\*\*\*\*\*" secret in the tools environment of your openshift cluster. Copy the username and password of this.
+
 Follow the instructions on [artifactory](https://developer.gov.bc.ca/Artifact-Repositories) to create an artifactory secret in each of the environments
-you will be building/deploying to.
+you will be building/deploying to. The `initOSProjects.sh` utility function in [openshift-developer-tools](https://github.com/BCDevOps/openshift-developer-tools) can also be used to autmatically set-up the pull credentials and links them to the service accounts.
 
 If you want to use your docker hub account, do the same command as for artifactory but use your docker.io login credentials.
+
 ##### Deploy:
 
-Once the secret is created, use the manage script in the openshift folder to deploy your project  
->./manage -n 4a9599 init  
-  
-This will generate local param files, make sure to go through each of the param files, uncomment NAMESPACE_NAME, and set it to your project namespace. In this case, 4a9599.  
+Once the secret is created, use the manage script in the openshift folder to deploy your project
 
-***If you're using a custom docker registry*** you will also need to uncomment and change DOCKER_REG and PULL_CREDS in `fathom-proxy-build.local.param` and SOURCE_IMAGE_NAME in `fathom-build.local.param`  
+> ./manage -n 4a9599 init
 
-Next we can build and deploy  
->./manage build
->./manage -e dev deploy
+This will generate local param files, make sure to go through each of the param files, uncomment NAMESPACE_NAME, and set it to your project namespace. In this case, 4a9599.
 
+**_If you're using a custom docker registry_** you will also need to uncomment and change DOCKER_REG and PULL_CREDS in `fathom-proxy-build.local.param` and SOURCE_IMAGE_NAME in `fathom-build.local.param`
+
+Next we can build and deploy
+
+> ./manage build
+> ./manage -e dev deploy
 
 ## First Run
+
 Once everything is up and running in OpenShift, follow the [instructions](https://github.com/usefathom/fathom/blob/master/docs/Installation%20instructions.md#register-your-admin-user) and create your admin user to secure the analytics dashboard.
 
 To start tracking, create a site in your Fathom dashboard and copy the tracking snippet to the website(s) you want to track.
 
 ## Filtering traffic from localhost and dev/test instances
+
 Fathom does not yet support defining filters to exclude traffic based on URL/referrer. To separate traffic coming from different environments it is necessary to use a different tracking ID for each instance.
 
 it is possible to achieve this by:
 
-1) importing a "generic" script to the app/pages you will want to track, like `<script type="text/javascript" src="/fathom.js"></script>`
-2) configuring your webserver to serve, if available, a static file containing the tracking code when receiving requests to `/fathom.js`.
-For nginx the configuration to add looks like this:
+1. importing a "generic" script to the app/pages you will want to track, like `<script type="text/javascript" src="/fathom.js"></script>`
+2. configuring your webserver to serve, if available, a static file containing the tracking code when receiving requests to `/fathom.js`.
+   For nginx the configuration to add looks like this:
+
 ```
 # serve the fathom analytics tracking code, if available
 location =/fathom.js {

--- a/openshift/manage
+++ b/openshift/manage
@@ -314,6 +314,7 @@ case "${_cmd}" in
     ;;
 
   build)
+    echoWarning "\nDeploying the build configuration.\nPlease wait for the build to complete before running any other command."
     genBuilds.sh -l
     ;;
 

--- a/openshift/manage
+++ b/openshift/manage
@@ -217,11 +217,21 @@ fi
 # -----------------------------------------------------------------------------------------------------------------
 # Functions:
 # -----------------------------------------------------------------------------------------------------------------
-updateDeploymentParams() {
-  (
-    _imageTag=${1:-"latest"}
+updateBuildParams() {
+  updateParams "build" "tools"
+}
 
-    _paramFiles=$(find . -name "*deploy.local.param")
+updateDeploymentParams() {
+  _imageTag=${1:-"dev"}
+  updateParams "deploy" $_imageTag
+}
+
+updateParams() {
+  (
+    _configType=${1}
+    _imageTag=${2}
+
+    _paramFiles=$(find . -name "*${_configType}.local.param")
     for paramFile in ${_paramFiles}; do
       # Uncomment and update the required deployment settings ...
       _parameterFilters="/TAG_NAME/s~^#.~~;"
@@ -246,8 +256,6 @@ deployApp(){
     if dcExists ${_appName}; then
       OPERATION=update genDepls.sh -u -l
     else
-      echoWarning "\nApplying required network security policies."
-      oc -n ${PROJECT_NAMESPACE}-${DEPLOYMENT_ENV_NAME} process -f ./templates/nsp/deploy.yaml -p NAMESPACE=${PROJECT_NAMESPACE}-${DEPLOYMENT_ENV_NAME} | oc create -f -
       genDepls.sh -l
     fi
 
@@ -288,6 +296,8 @@ initialize(){
   # Generate local params files ...
   echo "Generating local param files ..."
   genTemplateParams.sh -lf
+  updateBuildParams
+  updateDeploymentParams
 
   echo "Environment settings:"
   echo "  Project namespace: ${PROJECT_NAMESPACE}"
@@ -304,9 +314,6 @@ case "${_cmd}" in
     ;;
 
   build)
-    echoWarning "\nApplying required network security policies."
-    oc -n ${TOOLS} process -f ./templates/nsp/build.yaml -p NAMESPACE=${PROJECT_NAMESPACE} | oc create -f -
-    echoWarning "\nDeploying the build configuration.\nPlease wait for the build to complete before running any other command."
     genBuilds.sh -l
     ;;
 

--- a/openshift/manage
+++ b/openshift/manage
@@ -226,7 +226,9 @@ updateDeploymentParams() {
       # Uncomment and update the required deployment settings ...
       _parameterFilters="/TAG_NAME/s~^#.~~;"
       _parameterFilters="${_parameterFilters}/IMAGE_NAMESPACE/s~^#.~~;"
+      _parameterFilters="${_parameterFilters}/NAMESPACE_NAME/s~^#.~~;"
       _parameterFilters="${_parameterFilters}s~\(^TAG_NAME=\).*$~\1${_imageTag}~;"
+      _parameterFilters="${_parameterFilters}s~\(^NAMESPACE_NAME=\).*$~\1${PROJECT_NAMESPACE}~;"
 
       cat ${paramFile} | sed ${_parameterFilters} > ${paramFile}.tmp
       rm ${paramFile}
@@ -244,6 +246,8 @@ deployApp(){
     if dcExists ${_appName}; then
       OPERATION=update genDepls.sh -u -l
     else
+      echoWarning "\nApplying required network security policies."
+      oc -n ${PROJECT_NAMESPACE}-${DEPLOYMENT_ENV_NAME} process -f ./templates/nsp/deploy.yaml -p NAMESPACE=${PROJECT_NAMESPACE}-${DEPLOYMENT_ENV_NAME} | oc create -f -
       genDepls.sh -l
     fi
 
@@ -268,7 +272,7 @@ cleanResources()
 {
   (
     _appName=${1:-fathom}
-    oc -n $(getProjectName) delete all,configmap -l app=${_appName}
+    oc -n $(getProjectName) delete all,nsp,configmap -l app=${_appName}
   )
 }
 
@@ -300,6 +304,8 @@ case "${_cmd}" in
     ;;
 
   build)
+    echoWarning "\nApplying required network security policies."
+    oc -n ${TOOLS} process -f ./templates/nsp/build.yaml -p NAMESPACE=${PROJECT_NAMESPACE} | oc create -f -
     echoWarning "\nDeploying the build configuration.\nPlease wait for the build to complete before running any other command."
     genBuilds.sh -l
     ;;

--- a/openshift/templates/fathom-db/fathom-db-deploy.yaml
+++ b/openshift/templates/fathom-db/fathom-db-deploy.yaml
@@ -17,6 +17,7 @@ objects:
         app-group: ${APP_GROUP}
         role: ${ROLE}
         env: ${TAG_NAME}
+        backup: ${BACKUP}
     spec:
       strategy:
         type: Recreate
@@ -47,6 +48,7 @@ objects:
             app-group: ${APP_GROUP}
             role: ${ROLE}
             env: ${TAG_NAME}
+            backup: ${BACKUP}
         spec:
           volumes:
             - name: ${NAME}-data
@@ -54,7 +56,7 @@ objects:
                 claimName: ${NAME}
           containers:
             - name: ${NAME}
-              image: ' '
+              image: " "
               ports:
                 - containerPort: 5432
                   protocol: TCP
@@ -118,6 +120,7 @@ objects:
           dnsPolicy: ClusterFirst
           securityContext: {}
           schedulerName: default-scheduler
+
   - kind: PersistentVolumeClaim
     apiVersion: v1
     metadata:
@@ -128,6 +131,7 @@ objects:
         app-group: ${APP_GROUP}
         role: ${ROLE}
         env: ${TAG_NAME}
+        backup: ${BACKUP}
     spec:
       storageClassName: ${PERSISTENT_VOLUME_CLASS}
       accessModes:
@@ -135,6 +139,7 @@ objects:
       resources:
         requests:
           storage: ${PERSISTENT_VOLUME_SIZE}
+
   - kind: Secret
     apiVersion: v1
     metadata:
@@ -145,12 +150,14 @@ objects:
         app-group: ${APP_GROUP}
         role: ${ROLE}
         env: ${TAG_NAME}
+        backup: ${BACKUP}
     stringData:
       admin-password: ${POSTGRESQL_ADMIN_PASSWORD}
       database-password: ${POSTGRESQL_PASSWORD}
       database-user: ${POSTGRESQL_USER}
       database-name: ${POSTGRESQL_DATABASE_NAME}
     type: Opaque
+
   - kind: Service
     apiVersion: v1
     metadata:
@@ -161,6 +168,7 @@ objects:
         app-group: ${APP_GROUP}
         role: ${ROLE}
         env: ${TAG_NAME}
+        backup: ${BACKUP}
       annotations:
         template.openshift.io/expose-uri: postgres://{.spec.clusterIP}:{.spec.ports[?(.name=="postgresql")].port}
     spec:
@@ -173,17 +181,20 @@ objects:
         name: ${NAME}
       type: ClusterIP
       sessionAffinity: None
+
 parameters:
   - name: NAME
     displayName: Name
-    description: The name assigned to all of the OpenShift resources associated to
+    description:
+      The name assigned to all of the OpenShift resources associated to
       the server instance.
     required: true
     value: fathom-db
   - name: IMAGE_NAMESPACE
     displayName: Image Namespace
     required: true
-    description: The namespace of the OpenShift project containing the imagestream
+    description:
+      The namespace of the OpenShift project containing the imagestream
       for the application.
     value: myproject
   - name: SOURCE_IMAGE_NAME
@@ -196,6 +207,11 @@ parameters:
     description: The TAG name for this environment, e.g., dev, test, prod
     required: true
     value: prod
+  - name: BACKUP
+    displayName: Backup Flag
+    description: Determines whether this database should be accessible by a backup container. Defaults to "false".
+    required: true
+    value: "false"
   - name: APP_NAME
     displayName: App Name
     description: Used to group components together in the OpenShift console.
@@ -203,7 +219,8 @@ parameters:
     value: fathom
   - name: ROLE
     displayName: Role
-    description: The role of this service within the application - used for Network
+    description:
+      The role of this service within the application - used for Network
       Policies
     required: true
     value: db
@@ -211,7 +228,7 @@ parameters:
     displayName: Suffix
     description: A suffix applied to all of the objects in this template.
     required: false
-    value: ''
+    value: ""
   - name: APP_GROUP
     displayName: App Group
     description: The name assigned to all of the deployments in this project.
@@ -225,25 +242,28 @@ parameters:
     from: fathom.db
   - name: POSTGRESQL_USER
     displayName: PostgreSQL Connection Username
-    description: Username for PostgreSQL user that will be used for accessing the
+    description:
+      Username for PostgreSQL user that will be used for accessing the
       database.  Needs to be base64 encoded/
     required: true
     generate: expression
-    from: '[a-zA-Z0-9]{10}'
+    from: "[a-zA-Z0-9]{10}"
   - name: POSTGRESQL_PASSWORD
     displayName: PostgreSQL Connection Password
-    description: Password for the PostgreSQL connection user.  Needs to be base64
+    description:
+      Password for the PostgreSQL connection user.  Needs to be base64
       encoded/
     required: true
     generate: expression
-    from: '[a-zA-Z0-9]{16}'
+    from: "[a-zA-Z0-9]{16}"
   - name: POSTGRESQL_ADMIN_PASSWORD
     displayName: PostgreSQL Admin Password
-    description: Password for the 'postgres' PostgreSQL administrative account.  Needs
+    description:
+      Password for the 'postgres' PostgreSQL administrative account.  Needs
       to be base64 encoded.
     required: true
     generate: expression
-    from: '[a-zA-Z0-9]{16}'
+    from: "[a-zA-Z0-9]{16}"
   - name: MOUNT_PATH
     displayName: Mount Path
     description: The path to mount the persistent volume.

--- a/openshift/templates/fathom-proxy/fathom-proxy-build.yaml
+++ b/openshift/templates/fathom-proxy/fathom-proxy-build.yaml
@@ -3,29 +3,13 @@ apiVersion: v1
 metadata:
   name: ${NAME}-build-template
 objects:
-  - kind: NetworkSecurityPolicy
-    apiVersion: security.devops.gov.bc.ca/v1alpha1
-    metadata:
-      name: ${ENV_NAME}-pods-to-external-network
-      labels:
-        name: pods-to-external-network
-        env: ${ENV_NAME}
-    spec:
-      description: 'Allow the builds to access the internet.
-
-        This only needs to be specified once per environment.
-
-        '
-      source:
-        - - $namespace=${NAMESPACE_NAME}-${ENV_NAME}
-      destination:
-        - - ext:network=any
   - kind: ImageStream
     apiVersion: v1
     metadata:
       name: ${NAME}
       labels:
         app: ${APP_NAME}${SUFFIX}
+
   - kind: BuildConfig
     apiVersion: v1
     metadata:
@@ -45,11 +29,9 @@ objects:
         type: Docker
         dockerStrategy:
           dockerfilePath: ${DOCKER_FILE_PATH}
-          pullSecret:
-            name: ${PULL_CREDS}
           from:
             kind: DockerImage
-            name: ${DOCKER_REG}
+            name: ${SOURCE_IMAGE_NAME}
       output:
         to:
           kind: ImageStreamTag
@@ -63,6 +45,7 @@ objects:
           memory: ${MEMORY_LIMIT}
       triggers:
         - type: ConfigChange
+
 parameters:
   - name: NAME
     displayName: Name
@@ -78,25 +61,21 @@ parameters:
     displayName: Suffix
     description: A suffix applied to all of the objects in this template.
     required: false
-    value: ''
+    value: ""
   - name: APP_GROUP
     displayName: App Group
     description: The name assigned to all of the deployments in this project.
     required: true
     value: fathom-proxy
-  - name: DOCKER_REG
-    displayName: Docker-Registry
-    description: The name of the docker server
-    required: false
+  - name: SOURCE_IMAGE_NAME
+    displayName: Source Image Name
+    description: The name of the source image.
+    required: true
     value: docker-remote.artifacts.developer.gov.bc.ca/nginx:stable
-  - name: PULL_CREDS
-    displayName: Pull-Credentials
-    description: The name of the secret that will be used to pull from a docker server
-    required: false
-    value: artifactory-creds
   - name: ENV_NAME
     displayName: Environment Name
-    description: Environment name.  For the build environment this will typically
+    description:
+      Environment name.  For the build environment this will typically
       be 'tools'
     required: true
     value: tools
@@ -134,7 +113,7 @@ parameters:
     displayName: Resources CPU Limit
     description: The resources CPU limit (in cores) for this build.
     required: true
-    value: '0'
+    value: "0"
   - name: MEMORY_LIMIT
     displayName: Resources Memory Limit
     description: The resources Memory limit (in Mi, Gi, etc) for this build.
@@ -144,7 +123,7 @@ parameters:
     displayName: Resources CPU Request
     description: The resources CPU request (in cores) for this build.
     required: true
-    value: '0'
+    value: "0"
   - name: MEMORY_REQUEST
     displayName: Resources Memory Request
     description: The resources Memory request (in Mi, Gi, etc) for this build.

--- a/openshift/templates/fathom-proxy/fathom-proxy-deploy.yaml
+++ b/openshift/templates/fathom-proxy/fathom-proxy-deploy.yaml
@@ -6,9 +6,9 @@ objects:
   - kind: NetworkSecurityPolicy
     apiVersion: security.devops.gov.bc.ca/v1alpha1
     metadata:
-      name: custom-${APP_NAME}-${NAME}${SUFFIX}-policy
+      name: ${NAME}${SUFFIX}
       labels:
-        name: custom-${APP_NAME}-${NAME}${SUFFIX}-policy
+        name: ${NAME}${SUFFIX}
         app: ${APP_NAME}${SUFFIX}
         app-group: ${APP_GROUP}
         role: ${ROLE}
@@ -21,10 +21,11 @@ objects:
           - env=${TAG_NAME}
           - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
       destination:
-        - - role=api
+        - - role=${API_ROLE}
           - app=${APP_NAME}${SUFFIX}
           - env=${TAG_NAME}
           - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
+
   - kind: DeploymentConfig
     apiVersion: v1
     metadata:
@@ -74,6 +75,7 @@ objects:
                 - containerPort: 8080
                   protocol: TCP
               env: []
+
   - kind: Route
     apiVersion: v1
     metadata:
@@ -91,6 +93,7 @@ objects:
       to:
         kind: Service
         name: ${NAME}
+
   - kind: Service
     apiVersion: v1
     metadata:
@@ -115,17 +118,20 @@ objects:
         deploymentconfig: ${NAME}
       type: ClusterIP
       sessionAffinity: None
+
 parameters:
   - name: NAME
     displayName: Name
-    description: The name assigned to all of the OpenShift resources associated to
+    description:
+      The name assigned to all of the OpenShift resources associated to
       the server instance.
     required: true
     value: fathom-proxy
   - name: IMAGE_NAMESPACE
     displayName: Image Namespace
     required: true
-    description: The namespace of the OpenShift project containing the imagestream
+    description:
+      The namespace of the OpenShift project containing the imagestream
       for the application.
     value: myproject
   - name: SOURCE_IMAGE_NAME
@@ -139,21 +145,29 @@ parameters:
     required: true
     value: fathom
   - name: NAMESPACE_NAME
-    displayName: NameSpace name
-    description: name of the project namespace
+    displayName: Namespace Name
+    description: The name of the namespace being deployed to.
     required: true
     value: myproject
   - name: ROLE
     displayName: Role
-    description: The role of this service within the application - used for Network
+    description:
+      The role of this service within the application - used for Network
       Policies
     required: true
     value: proxy
+  - name: API_ROLE
+    displayName: API Role
+    description:
+      The role of the API service within the application - used for Network
+      Policies
+    required: true
+    value: api
   - name: SUFFIX
     displayName: Suffix
     description: A suffix applied to all of the objects in this template.
     required: false
-    value: ''
+    value: ""
   - name: APP_GROUP
     displayName: App Group
     description: The name assigned to all of the deployments in this project.
@@ -166,10 +180,11 @@ parameters:
     value: prod
   - name: FATHOM_URL
     displayName: Fathom URL
-    description: The public domain endpoint for Fathom. A value will be created by
+    description:
+      The public domain endpoint for Fathom. A value will be created by
       default if not specified.
     required: false
-    value: ''
+    value: ""
   - name: CPU_REQUEST
     displayName: Resources CPU Request
     description: The resources CPU request (in cores) for this build.

--- a/openshift/templates/fathom/fathom-build.yaml
+++ b/openshift/templates/fathom/fathom-build.yaml
@@ -18,10 +18,12 @@ objects:
             name: ${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}
           importPolicy:
             scheduled: true
+
 parameters:
   - name: NAME
     displayName: Name
-    description: The name assigned to all of the frontend objects defined in this
+    description:
+      The name assigned to all of the frontend objects defined in this
       template.  You should keep this as default unless your know what your doing.
     required: true
     value: fathom
@@ -34,7 +36,7 @@ parameters:
     displayName: Suffix
     description: A suffix applied to all of the objects in this template.
     required: false
-    value: ''
+    value: ""
   - name: OUTPUT_IMAGE_TAG
     displayName: Output Image Tag
     description: The tag given to the built image.
@@ -42,7 +44,8 @@ parameters:
     value: version-1.2.1
   - name: SOURCE_IMAGE_KIND
     displayName: Source Image Kind
-    description: The 'kind' (type) of the  source image; typically ImageStreamTag,
+    description:
+      The 'kind' (type) of the  source image; typically ImageStreamTag,
       or DockerImage.
     required: true
     value: DockerImage

--- a/openshift/templates/fathom/fathom-deploy.yaml
+++ b/openshift/templates/fathom/fathom-deploy.yaml
@@ -3,6 +3,29 @@ apiVersion: v1
 metadata:
   name: ${NAME}-deployment-template
 objects:
+  - kind: NetworkSecurityPolicy
+    apiVersion: security.devops.gov.bc.ca/v1alpha1
+    metadata:
+      name: ${NAME}${SUFFIX}
+      labels:
+        name: ${NAME}${SUFFIX}
+        app: ${APP_NAME}${SUFFIX}
+        app-group: ${APP_GROUP}
+        role: ${ROLE}
+        env: ${TAG_NAME}
+    spec:
+      description: Allow Fathom api to access Fathom DB
+      source:
+        - - role=${ROLE}
+          - app=${APP_NAME}${SUFFIX}
+          - env=${TAG_NAME}
+          - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
+      destination:
+        - - role=${DB_ROLE}
+          - app=${APP_NAME}${SUFFIX}
+          - env=${TAG_NAME}
+          - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
+
   - kind: DeploymentConfig
     apiVersion: v1
     metadata:
@@ -32,13 +55,12 @@ objects:
       replicas: 1
       test: false
       selector:
-        app: fathom
-        deploymentconfig: ${NAME}
+        app: ${APP_NAME}${SUFFIX}
+        env: ${TAG_NAME}
       template:
         metadata:
           labels:
             app: ${APP_NAME}${SUFFIX}
-            deploymentconfig: ${NAME}
             app-group: ${APP_GROUP}
             role: ${ROLE}
             env: ${TAG_NAME}
@@ -78,28 +100,7 @@ objects:
                 limits:
                   cpu: ${CPU_LIMIT}
                   memory: ${MEMORY_LIMIT}
-  - kind: NetworkSecurityPolicy
-    apiVersion: security.devops.gov.bc.ca/v1alpha1
-    metadata:
-      name: custom-${APP_NAME}-${NAME}${SUFFIX}-policy
-      labels:
-        name: custom-${APP_NAME}-${NAME}${SUFFIX}-policy
-        app: ${APP_NAME}${SUFFIX}
-        app-group: ${APP_GROUP}
-        role: ${ROLE}
-        env: ${TAG_NAME}
-    spec:
-      description: Allow Fathom api to access Fathom DB
-      source:
-        - - role=${ROLE}
-          - app=${APP_NAME}${SUFFIX}
-          - env=${TAG_NAME}
-          - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
-      destination:
-        - - role=db
-          - app=${APP_NAME}${SUFFIX}
-          - env=${TAG_NAME}
-          - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
+
   - kind: Service
     apiVersion: v1
     metadata:
@@ -121,17 +122,20 @@ objects:
         deploymentconfig: ${NAME}
       type: ClusterIP
       sessionAffinity: None
+
 parameters:
   - name: NAME
     displayName: Name
-    description: The name assigned to all of the OpenShift resources associated to
+    description:
+      The name assigned to all of the OpenShift resources associated to
       the server instance.
     required: true
     value: fathom
   - name: IMAGE_NAMESPACE
     displayName: Image Namespace
     required: true
-    description: The namespace of the OpenShift project containing the imagestream
+    description:
+      The namespace of the OpenShift project containing the imagestream
       for the application.
     value: myproject
   - name: SOURCE_IMAGE_NAME
@@ -145,21 +149,29 @@ parameters:
     required: true
     value: fathom
   - name: NAMESPACE_NAME
-    displayName: NameSpace name
-    description: name of the project namespace
+    displayName: Namespace Name
+    description: The name of the namespace being deployed to.
     required: true
     value: myproject
   - name: ROLE
     displayName: Role
-    description: The role of this service within the application - used for Network
+    description:
+      The role of this service within the application - used for Network
       Policies
     required: true
     value: api
+  - name: DB_ROLE
+    displayName: Role
+    description:
+      The role of teh DB service within the application - used for Network
+      Policies
+    required: true
+    value: db
   - name: SUFFIX
     displayName: Suffix
     description: A suffix applied to all of the objects in this template.
     required: false
-    value: ''
+    value: ""
   - name: APP_GROUP
     displayName: App Group
     description: The name assigned to all of the deployments in this project.
@@ -182,7 +194,8 @@ parameters:
     value: fathom-db
   - name: FATHOM_DATABASE_SSLMODE
     displayName: Fathom Database SSL Mode
-    description: The flag indicating wether to use SSL to connect to the database.
+    description:
+      The flag indicating wether to use SSL to connect to the database.
       For postgresql it must be 'disable'.
     required: true
     value: disable

--- a/openshift/templates/nsp/build.yaml
+++ b/openshift/templates/nsp/build.yaml
@@ -10,13 +10,13 @@ objects:
       name: pods-to-k8s-api
       labels:
         name: pods-to-k8s-api
-        env: ${ENV_NAME}
+        env: ${TAG_NAME}
     spec:
       description: |
         Allow pods to talk to the internal k8s api so builds work.
         This only needs to be specified once per environment.
       source:
-        - - $namespace=${NAMESPACE}-${ENV_NAME}
+        - - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
       destination:
         - - int:network=internal-cluster-api-endpoint
 
@@ -42,22 +42,22 @@ objects:
       name: pods-to-external-network
       labels:
         name: pods-to-external-network
-        env: ${ENV_NAME}
+        env: ${TAG_NAME}
     spec:
       description: |
         Allow the builds to access the internet.
         This only needs to be specified once per environment.
       source:
-        - - $namespace=${NAMESPACE}-${ENV_NAME}
+        - - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
       destination:
         - - ext:name=internet-build-resources
 
 parameters:
-  - name: NAMESPACE
+  - name: NAMESPACE_NAME
     displayName: The target namespace for the resources.
     required: true
     value: 
-  - name: ENV_NAME
+  - name: TAG_NAME
     displayName: Environment Name
     description: Environment name.  For the build environment this will typically be 'tools'
     required: true

--- a/openshift/templates/nsp/build.yaml
+++ b/openshift/templates/nsp/build.yaml
@@ -1,0 +1,64 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: global-nsp-build-template
+objects:
+  - kind: NetworkSecurityPolicy
+    apiVersion: security.devops.gov.bc.ca/v1alpha1
+    metadata:
+      name: pods-to-k8s-api
+      labels:
+        name: pods-to-k8s-api
+        env: ${ENV_NAME}
+    spec:
+      description: |
+        Allow pods to talk to the internal k8s api so builds work.
+        This only needs to be specified once per environment.
+      source:
+        - - $namespace=${NAMESPACE}-${ENV_NAME}
+      destination:
+        - - int:network=internal-cluster-api-endpoint
+
+  - kind: ExternalNetwork
+    apiVersion: security.devops.gov.bc.ca/v1alpha1
+    metadata:
+      name: internet-build-resources
+      network: internet-build-resources
+      labels:
+        name: internet-build-resources
+        network: internet-build-resources
+    spec:
+      description: |
+        Define the network parameters for accessing https resources on internet.
+      entries:
+        - 0.0.0.0/0
+      servicePorts:
+        - tcp/443
+
+  - kind: NetworkSecurityPolicy
+    apiVersion: security.devops.gov.bc.ca/v1alpha1
+    metadata:
+      name: pods-to-external-network
+      labels:
+        name: pods-to-external-network
+        env: ${ENV_NAME}
+    spec:
+      description: |
+        Allow the builds to access the internet.
+        This only needs to be specified once per environment.
+      source:
+        - - $namespace=${NAMESPACE}-${ENV_NAME}
+      destination:
+        - - ext:name=internet-build-resources
+
+parameters:
+  - name: NAMESPACE
+    displayName: The target namespace for the resources.
+    required: true
+    value: 
+  - name: ENV_NAME
+    displayName: Environment Name
+    description: Environment name.  For the build environment this will typically be 'tools'
+    required: true
+    value: tools

--- a/openshift/templates/nsp/deploy.yaml
+++ b/openshift/templates/nsp/deploy.yaml
@@ -1,0 +1,32 @@
+---
+kind: Template
+apiVersion: v1
+metadata:
+  name: global-nsp-build-template
+objects:
+  - kind: NetworkSecurityPolicy
+    apiVersion: security.devops.gov.bc.ca/v1alpha1
+    metadata:
+      name: pods-to-k8s-api
+      labels:
+        name: pods-to-k8s-api
+        env: ${ENV_NAME}
+    spec:
+      description: |
+        Allow pods to talk to the internal k8s api so deployments work.
+        This only needs to be specified once per environment.
+      source:
+        - - $namespace=${NAMESPACE}-${ENV_NAME}
+      destination:
+        - - int:network=internal-cluster-api-endpoint
+
+parameters:
+  - name: NAMESPACE
+    displayName: The target namespace for the resources.
+    required: true
+    value:
+  - name: ENV_NAME
+    displayName: Environment Name
+    description: Environment name.  For the build environment this will typically be 'tools'
+    required: true
+    value: dev

--- a/openshift/templates/nsp/deploy.yaml
+++ b/openshift/templates/nsp/deploy.yaml
@@ -10,22 +10,22 @@ objects:
       name: pods-to-k8s-api
       labels:
         name: pods-to-k8s-api
-        env: ${ENV_NAME}
+        env: ${TAG_NAME}
     spec:
       description: |
         Allow pods to talk to the internal k8s api so deployments work.
         This only needs to be specified once per environment.
       source:
-        - - $namespace=${NAMESPACE}-${ENV_NAME}
+        - - $namespace=${NAMESPACE_NAME}-${TAG_NAME}
       destination:
         - - int:network=internal-cluster-api-endpoint
 
 parameters:
-  - name: NAMESPACE
+  - name: NAMESPACE_NAME
     displayName: The target namespace for the resources.
     required: true
     value:
-  - name: ENV_NAME
+  - name: TAG_NAME
     displayName: Environment Name
     description: Environment name.  For the build environment this will typically be 'tools'
     required: true

--- a/openshift/templates/postgresql/postgresql-build.yaml
+++ b/openshift/templates/postgresql/postgresql-build.yaml
@@ -18,10 +18,12 @@ objects:
             name: ${SOURCE_IMAGE_NAME}:${SOURCE_IMAGE_TAG}
           importPolicy:
             scheduled: true
+
 parameters:
   - name: NAME
     displayName: Name
-    description: The name assigned to all of the frontend objects defined in this
+    description:
+      The name assigned to all of the frontend objects defined in this
       template.  You should keep this as default unless your know what your doing.
     required: true
     value: postgresql
@@ -32,7 +34,8 @@ parameters:
     value: latest
   - name: SOURCE_IMAGE_KIND
     displayName: Source Image Kind
-    description: The 'kind' (type) of the  source image; typically ImageStreamTag,
+    description:
+      The 'kind' (type) of the  source image; typically ImageStreamTag,
       or DockerImage.
     required: true
     value: DockerImage
@@ -45,7 +48,7 @@ parameters:
     displayName: Suffix
     description: A suffix applied to all of the objects in this template.
     required: false
-    value: ''
+    value: ""
   - name: SOURCE_IMAGE_NAME
     displayName: Source Image Name
     description: The name of the source image.


### PR DESCRIPTION
Tweaked build, deployment configurations to follow the most recent pattern used in other projects (see Matomo as an example).

I updated the manage `script` to replace the name of the environment automatically as @WadeBarnes  did for Matomo, but for some reason it is not working as expected for me. I may pick it up again later to confirm, if any of you has a second to test that `NAMESPACE_NAME` is replaced as expected it would be great.